### PR TITLE
chore: change the aggregate_column method to protected from private

### DIFF
--- a/lib/baby_squeel/active_record/calculations.rb
+++ b/lib/baby_squeel/active_record/calculations.rb
@@ -28,7 +28,7 @@ module BabySqueel
         maximum Calculation.new(DSL.evaluate(self, &block))
       end
 
-      private
+      protected
 
       # @override
       def aggregate_column(column_name)


### PR DESCRIPTION
In the main, the pipeline was red. We were getting the following error- 

```
NoMethodError: private method `aggregate_column' called for #<ActiveRecord::Relation
``` 
With this fix, the pipeline is green now.