### PR TITLE
chore: added support for ransack 4.4.x

### DIFF
--- a/lib/baby_squeel.rb
+++ b/lib/baby_squeel.rb
@@ -4,10 +4,6 @@ require 'active_record/relation'
 require 'polyamorous/polyamorous'
 require 'baby_squeel/version'
 require 'baby_squeel/errors'
-require 'baby_squeel/active_record/base'
-require 'baby_squeel/active_record/query_methods'
-require 'baby_squeel/active_record/calculations'
-require 'baby_squeel/active_record/where_chain'
 
 module BabySqueel
   class << self
@@ -43,6 +39,11 @@ module BabySqueel
 end
 
 ActiveSupport.on_load :active_record do
+  require 'baby_squeel/active_record/base'
+  require 'baby_squeel/active_record/query_methods'
+  require 'baby_squeel/active_record/calculations'
+  require 'baby_squeel/active_record/where_chain'
+  
   ::ActiveRecord::Base.extend BabySqueel::ActiveRecord::Base
   ::ActiveRecord::Relation.prepend BabySqueel::ActiveRecord::QueryMethods
   ::ActiveRecord::Relation.prepend BabySqueel::ActiveRecord::Calculations


### PR DESCRIPTION
Previous error-

```
/Users/wti0405/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/baby_squeel-9b8d3d687233/lib/baby_squeel/join.rb:7:in '<class:Join>': uninitialized constant BabySqueel::Join::Polyamorous (NameError)

    include Polyamorous::TreeNode
            ^^^^^^^^^^^
	from /Users/wti0405/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/baby_squeel-9b8d3d687233/lib/baby_squeel/join.rb:6:in '<module:BabySqueel>'
	from /Users/wti0405/.rbenv/versions/3.4.5/lib/ruby/gems/3.4.0/bundler/gems/baby_squeel-9b8d3d687233/lib/baby_squeel/join.rb:1:in '<main>'
	from /Users/wti0405/.rbenv/versions/3.4.5/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from 
```

Previously- Ransack (and essentially Polymorous) was loaded immediately when baby-squeel was initialized.

But ransack changed their code to only load it whenever it is needed(== AR is needed). Hence we are loading the AR classes when active support is loading AR. This ensures when the following code runs, we already have Polymorous loaded-

```
module BabySqueel
  # This is the thing that gets added to Active Record's joins_values.
  # By including Polyamorous::TreeNode, when this instance is found when
  # traversing joins in ActiveRecord::Associations::JoinDependency::walk_tree,
  # Join#add_to_tree will be called.
  class Join
    include Polyamorous::TreeNode
```